### PR TITLE
Port Skill Creator to PySide6 with material themes

### DIFF
--- a/Skill Creator/Program/ui_create_skill.py
+++ b/Skill Creator/Program/ui_create_skill.py
@@ -1,266 +1,248 @@
 # -*- coding: utf-8 -*-
-"""
-///summary
-Formulaire GUI: création de compétence
-- Première ligne plus grosse: Famille (30%) + Nom (70%)
-- Dropdown familles = "émojis — nom" mais stockage = émojis
-- Tous les champs dans une zone scrollable (molette OK)
-- Boutons fixes en bas (toujours visibles) : Enregistrer / Vider / Rafraîchir familles
-- Sélecteur de type pour "Difficultés / Facilités" : boutons "Difficulté" / "Facilité" + champ valeur
-"""
-import tkinter as tk
-from tkinter import ttk, messagebox
-import platform
-import tkinter.font as tkfont
+"""Skill creation tab using PySide6 widgets."""
+from __future__ import annotations
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QHBoxLayout,
+    QRadioButton,
+    QButtonGroup,
+    QComboBox,
+    QMessageBox,
+    QPushButton,
+    QCheckBox,
+    QScrollArea,
+)
 
 from .datastore import DataStore
 from .models import Skill
-from .widgets import LabeledEntry, LabeledText, ScrollableFrame
+from .widgets import LabeledLineEdit, LabeledTextEdit
 
-PAD = 8
 
-class CreateSkillFrame(ttk.Frame):
-    def __init__(self, master, store: DataStore):
-        super().__init__(master, padding=PAD)
+class CreateSkillTab(QWidget):
+    """Form allowing the user to create a new skill."""
+
+    skill_created = Signal()
+
+    def __init__(self, store: DataStore, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
         self.store = store
-        self._display_to_emojis = {}  # "🌊 — Magie d'Eau" -> "🌊"
+        self._display_to_emojis: dict[str, str] = {}
 
-        # Titre
-        ttk.Label(self, text="Créer une Compétence", font=("Segoe UI", 14, "bold")).pack(anchor="w", pady=(0, PAD))
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(16, 16, 16, 16)
+        main_layout.setSpacing(12)
 
-        # Zone scrollable pour tous les champs
-        scroll = ScrollableFrame(self)
-        scroll.pack(fill="both", expand=True, pady=(0, PAD))
-        self._scroll = scroll                 # ← garde une ref. pour suspend_wheel/resume_wheel
-        body = scroll.body
-        
-        # --- Ligne "Niveau" (AVANT Famille/Nom) ---
-        level_row = ttk.Frame(body)
-        level_row.pack(fill="x", pady=(0, PAD))  # première ligne du formulaire
-        ttk.Label(level_row, text="Niveau :", font=("Segoe UI", 10, "bold")).pack(side="left", padx=(0, 6))
-        self.level_var = tk.StringVar(value="Niv1")
+        title = QLabel("Créer une Compétence")
+        title.setStyleSheet("font-size: 20px; font-weight: bold;")
+        main_layout.addWidget(title)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        main_layout.addWidget(scroll_area, 1)
+
+        form_container = QWidget()
+        scroll_area.setWidget(form_container)
+
+        form_layout = QVBoxLayout(form_container)
+        form_layout.setContentsMargins(0, 0, 0, 0)
+        form_layout.setSpacing(12)
+
+        level_row = QHBoxLayout()
+        level_label = QLabel("Niveau :")
+        level_label.setStyleSheet("font-weight: bold;")
+        level_row.addWidget(level_label)
+        self.level_group = QButtonGroup(self)
         for label in ("Niv1", "Niv2", "Niv3"):
-            ttk.Radiobutton(level_row, text=label, value=label, variable=self.level_var).pack(side="left", padx=(4, 0))
+            btn = QRadioButton(label)
+            if label == "Niv1":
+                btn.setChecked(True)
+            self.level_group.addButton(btn)
+            level_row.addWidget(btn)
+        level_row.addStretch(1)
+        form_layout.addLayout(level_row)
 
+        header_row = QHBoxLayout()
+        header_row.setSpacing(12)
 
-        # === Première ligne (plus grosse) : Famille (30%) + Nom (70%)
-        header = ttk.Frame(body)
-        header.pack(fill="x", pady=(0, PAD))
-        header.grid_columnconfigure(0, weight=2)  # 30%
-        header.grid_columnconfigure(1, weight=7)  # 70%
+        family_column = QVBoxLayout()
+        family_label = QLabel("Famille *")
+        family_label.setStyleSheet("font-weight: bold;")
+        family_column.addWidget(family_label)
+        self.family_combo = QComboBox()
+        self.family_combo.setEditable(False)
+        family_column.addWidget(self.family_combo)
+        header_row.addLayout(family_column, 2)
 
-        # Famille
-        fam_col = ttk.Frame(header)
-        fam_col.grid(row=0, column=0, sticky="ew", padx=(0, PAD))
-        self.lbl_family = ttk.Label(fam_col, text="Famille *")  # ← référence
-        self.lbl_family.pack(anchor="w")
-        self.family_var = tk.StringVar(value="")
-        self.family_cb = ttk.Combobox(fam_col, textvariable=self.family_var, values=(), state="readonly")
-        self.family_cb.pack(fill="x")
-        
-        # Nom
-        name_col = ttk.Frame(header)
-        name_col.grid(row=0, column=1, sticky="ew")
-        self.lbl_name = ttk.Label(name_col, text="Nom *")  # ← référence
-        self.lbl_name.pack(anchor="w")
-        self.name_var = tk.StringVar()
-        self.name_entry = ttk.Entry(name_col, textvariable=self.name_var)
-        self.name_entry.pack(fill="x")
-        
-        self._apply_big_header_fonts()
-        self._install_combobox_scroll_guard(self.family_cb)
-        
-        # Astuce si aucune famille
-        if not self.store.families:
-            ttk.Label(
-                body,
-                foreground="#a33",
-                wraplength=520,
-                text="Astuce: vous n'avez pas encore de famille. Créez-en une via le bouton 'Créer Famille'."
-            ).pack(anchor="w", pady=(PAD, 0))
+        name_column = QVBoxLayout()
+        name_label = QLabel("Nom *")
+        name_label.setStyleSheet("font-weight: bold;")
+        name_column.addWidget(name_label)
+        self.name = LabeledLineEdit("", width=40)
+        # remove placeholder label created by LabeledLineEdit when reused
+        self.name.set_label_visible(False)
+        self.name.setPlaceholderText("Nom de la compétence")
+        name_column.addWidget(self.name)
+        header_row.addLayout(name_column, 5)
 
-        # --- Ligne "Difficulté / Facilité" ---
-        diff_row = ttk.Frame(body)
-        diff_row.pack(fill="x", pady=(0, PAD))
+        form_layout.addLayout(header_row)
 
-        ttk.Label(diff_row, text="Type :", font=("Segoe UI", 10, "bold")).pack(side="left", padx=(0, 6))
-        self.diff_type_var = tk.StringVar(value="Difficulté")
-        ttk.Radiobutton(diff_row, text="Difficulté", value="Difficulté", variable=self.diff_type_var).pack(side="left")
-        ttk.Radiobutton(diff_row, text="Facilité", value="Facilité", variable=self.diff_type_var).pack(side="left", padx=(8, 0))
-        ttk.Radiobutton(diff_row, text="Passif", value="Passif", variable=self.diff_type_var).pack(side="left", padx=(8, 0))
+        self._hint_label = QLabel(
+            "Astuce: vous n'avez pas encore de famille. Créez-en une via le bouton 'Créer Famille'."
+        )
+        self._hint_label.setWordWrap(True)
+        self._hint_label.setStyleSheet("color: #a33;")
+        form_layout.addWidget(self._hint_label)
 
-        self.diff_value = LabeledEntry(body, "Valeur (ex: -2 aux jets d'attaque)")
-        self.diff_value.pack(fill="x", pady=(0, PAD))
+        diff_row = QHBoxLayout()
+        diff_label = QLabel("Type :")
+        diff_label.setStyleSheet("font-weight: bold;")
+        diff_row.addWidget(diff_label)
+        self.diff_radio_diff = QRadioButton("Difficulté")
+        self.diff_radio_diff.setChecked(True)
+        self.diff_radio_fac = QRadioButton("Facilité")
+        self.diff_radio_passif = QRadioButton("Passif")
+        diff_row.addWidget(self.diff_radio_diff)
+        diff_row.addWidget(self.diff_radio_fac)
+        diff_row.addWidget(self.diff_radio_passif)
+        diff_row.addStretch(1)
+        form_layout.addLayout(diff_row)
 
-        # Champs simples
-        self.cost = LabeledEntry(body, "Coût")
-        self.target = LabeledEntry(body, "Cible")
-        self.range_ = LabeledEntry(body, "Portée")
-        self.duration = LabeledEntry(body, "Durée")
-        self.damage = LabeledEntry(body, "Dégâts")
+        self.diff_value = LabeledLineEdit("Valeur (ex: -2 aux jets d'attaque)")
+        form_layout.addWidget(self.diff_value)
 
-        for w in (self.cost, self.target, self.range_, self.duration, self.damage):
-            w.pack(fill="x", pady=(0, PAD))
+        self.cost = LabeledLineEdit("Coût")
+        self.target = LabeledLineEdit("Cible")
+        self.range_ = LabeledLineEdit("Portée")
+        self.duration = LabeledLineEdit("Durée")
+        self.damage = LabeledLineEdit("Dégâts")
 
-        # Champs multi-lignes
-        self.effects = LabeledText(body, "Effet(s)")
-        self.conditions = LabeledText(body, "Condition(s)")
-        self.limits = LabeledText(body, "Limite(s)")
-        self.effects.pack(fill="both", expand=True, pady=(0, PAD))
-        self.conditions.pack(fill="both", expand=True, pady=(0, PAD))
-        self.limits.pack(fill="both", expand=True, pady=(0, PAD))
+        for widget in (self.cost, self.target, self.range_, self.duration, self.damage):
+            form_layout.addWidget(widget)
 
-        # ///summary: Case à cocher "Masquer cet item dans les index"
-        hide_row = ttk.Frame(body)
-        hide_row.pack(fill="x", pady=(0, PAD))
-        self.hidden_var = tk.BooleanVar(value=False)
-        ttk.Checkbutton(hide_row, text="Masquer dans les index (hided)", variable=self.hidden_var).pack(anchor="w")
+        self.effects = LabeledTextEdit("Effet(s)")
+        self.conditions = LabeledTextEdit("Condition(s)")
+        self.limits = LabeledTextEdit("Limite(s)")
 
+        form_layout.addWidget(self.effects)
+        form_layout.addWidget(self.conditions)
+        form_layout.addWidget(self.limits)
 
-        # Boutons fixes (hors zone scrollable)
-        btns = ttk.Frame(self)
-        btns.pack(fill="x", pady=(PAD, 0))
-        ttk.Button(btns, text="Enregistrer", command=self._save).pack(side="left")
-        ttk.Button(btns, text="Vider le formulaire", command=self._clear).pack(side="left", padx=(PAD, 0))
-        ttk.Button(btns, text="Rafraîchir familles", command=self._refresh_families).pack(side="left", padx=(PAD, 0))
+        self.hidden_checkbox = QCheckBox("Masquer dans les index (hided)")
+        form_layout.addWidget(self.hidden_checkbox)
 
-        # Init des familles pour le dropdown
-        self._refresh_families()
+        button_row = QHBoxLayout()
+        save_btn = QPushButton("Enregistrer")
+        save_btn.clicked.connect(self._save)
+        button_row.addWidget(save_btn)
 
-    def _emoji_font_name(self) -> str:
-        # Police emoji selon l’OS (fallback si introuvable)
-        sysname = platform.system()
-        if sysname == "Windows":
-            return "Segoe UI Emoji"
-        if sysname == "Darwin":
-            return "Apple Color Emoji"
-        return "Noto Color Emoji"  # Linux
+        clear_btn = QPushButton("Vider le formulaire")
+        clear_btn.clicked.connect(self._clear)
+        button_row.addWidget(clear_btn)
 
-    def _apply_big_header_fonts(self, emoji_pt: int = 18, name_pt: int = 13, label_pt: int = 12):
-        # Police pour les émojis dans le Combobox
-        try:
-            emoji_font = tkfont.Font(family=self._emoji_font_name(), size=emoji_pt)
-        except tk.TclError:
-            emoji_font = tkfont.Font(size=emoji_pt)  # fallback
+        refresh_btn = QPushButton("Rafraîchir familles")
+        refresh_btn.clicked.connect(self.refresh_families)
+        button_row.addWidget(refresh_btn)
 
-        # Police labels en gras
-        label_bold = tkfont.Font(size=label_pt, weight="bold")
-        # Police pour l'Entry Nom
-        name_font = tkfont.Font(size=name_pt)
+        button_row.addStretch(1)
+        main_layout.addLayout(button_row)
 
-        # 1) Entrée du Combobox (zone éditable) → emoji plus gros
-        self.family_cb.configure(font=emoji_font)
+        self.refresh_families()
 
-        # 2) Liste déroulante du Combobox → la même police (emoji gros dans le menu)
-        #    Global pour tous les Combobox (simple et fiable)
-        self.option_add("*TCombobox*Listbox.font", emoji_font)
+    def set_store(self, store: DataStore) -> None:
+        self.store = store
+        self.refresh_families()
 
-        # 3) Labels plus lisibles
-        self.lbl_family.configure(font=label_bold)
-        self.lbl_name.configure(font=label_bold)
+    def refresh_families(self) -> None:
+        current_display = self.family_combo.currentText()
+        pairs = self._build_family_choices()
+        values = [display for display, _ in pairs]
+        self._display_to_emojis = {display: emojis for display, emojis in pairs}
 
-        # 4) Champ Nom un peu plus grand
-        self.name_entry.configure(font=name_font)
+        self.family_combo.blockSignals(True)
+        self.family_combo.clear()
+        self.family_combo.addItems(values)
+        self.family_combo.blockSignals(False)
 
+        if values:
+            if current_display in values:
+                self.family_combo.setCurrentIndex(values.index(current_display))
+            elif self.family_combo.currentIndex() < 0:
+                self.family_combo.setCurrentIndex(0)
+        self._hint_label.setVisible(not bool(values))
 
-    # ///summary: Construit la liste d’affichage "émojis — nom" et la map display->emojis.
-    def _build_family_choices(self):
-        pairs = []
+    def _build_family_choices(self) -> list[tuple[str, str]]:
+        pairs: list[tuple[str, str]] = []
         for fam in self.store.families:
             display = f"{fam.emojis} — {fam.name}" if fam.name.strip() else fam.emojis
             pairs.append((display, fam.emojis))
-        pairs.sort(key=lambda p: p[0])
+        pairs.sort(key=lambda item: item[0])
         return pairs
 
-    def _refresh_families(self):
-        pairs = self._build_family_choices()
-        values = [d for d, _ in pairs]
-        self._display_to_emojis = {d: e for d, e in pairs}
-        self.family_cb["values"] = values
-        if values:
-            if self.family_var.get() not in values:
-                self.family_var.set(values[0])
-        else:
-            self.family_var.set("")
-
     def _clear(self) -> None:
-        self.name_var.set("")
-        self.diff_type_var.set("Difficulté")
-        self.diff_value.var.set("")
-        self.cost.var.set("")
-        self.target.var.set("")
-        self.range_.var.set("")
-        self.damage.var.set("")
-        self.effects.text.delete("1.0", "end")
-        self.conditions.text.delete("1.0", "end")
-        self.limits.text.delete("1.0", "end")
-        self.duration.var.set("")
-        self.hidden_var.set(False)
-
-
+        self.name.setText("")
+        self.diff_radio_diff.setChecked(True)
+        self.diff_value.setText("")
+        for widget in (self.cost, self.target, self.range_, self.duration, self.damage):
+            widget.setText("")
+        self.effects.clear()
+        self.conditions.clear()
+        self.limits.clear()
+        self.hidden_checkbox.setChecked(False)
+        if self.family_combo.count() > 0:
+            self.family_combo.setCurrentIndex(0)
+        for btn in self.level_group.buttons():
+            if btn.text() == "Niv1":
+                btn.setChecked(True)
+                break
 
     def _save(self) -> None:
-        # Famille (clé émojis) depuis la sélection affichée
-        display = self.family_var.get().strip()
+        display = self.family_combo.currentText().strip()
         family_emojis = self._display_to_emojis.get(display, "").strip()
         if not family_emojis:
-            messagebox.showwarning("Famille requise", "Merci de choisir une famille.")
+            QMessageBox.warning(self, "Famille requise", "Merci de choisir une famille.")
             return
 
-        name = self.name_var.get().strip()
+        name = self.name.text().strip()
         if not name:
-            messagebox.showwarning("Nom requis", "La compétence doit avoir un nom.")
+            QMessageBox.warning(self, "Nom requis", "La compétence doit avoir un nom.")
             return
 
-        # Construit le champ "Difficultés / Facilités" en string
-        diff_label = self.diff_type_var.get()
-        diff_text = self.diff_value.var.get().strip()
+        if self.diff_radio_fac.isChecked():
+            diff_label = "Facilité"
+        elif self.diff_radio_passif.isChecked():
+            diff_label = "Passif"
+        else:
+            diff_label = "Difficulté"
+        diff_text = self.diff_value.text().strip()
         difficulty_field = f"{diff_label} : {diff_text}" if diff_text else diff_label
 
+        level_button = self.level_group.checkedButton()
+        level = level_button.text() if level_button else "Niv1"
+
         skill = Skill(
-            family=family_emojis,  # on stocke uniquement la clé émojis
+            family=family_emojis,
             name=name,
-            cost=self.cost.var.get().strip(),
-            difficulty=difficulty_field,          # ← string combiné
-            target=self.target.var.get().strip(),
-            range_=self.range_.var.get().strip(),
-            damage=self.damage.var.get().strip(),
+            cost=self.cost.text().strip(),
+            difficulty=difficulty_field,
+            target=self.target.text().strip(),
+            range_=self.range_.text().strip(),
+            damage=self.damage.text().strip(),
             effects=self.effects.get_lines(),
             conditions=self.conditions.get_lines(),
             limits=self.limits.get_lines(),
-            duration=self.duration.var.get().strip(),
-            level=self.level_var.get(),
-            hided=self.hidden_var.get(),
-
-
+            duration=self.duration.text().strip(),
+            level=level,
+            hided=self.hidden_checkbox.isChecked(),
         )
+
         try:
             self.store.add_skill(skill)
-            messagebox.showinfo("OK", f"Compétence '{name}' ajoutée.")
+            QMessageBox.information(self, "OK", f"Compétence '{name}' ajoutée.")
             self._clear()
-        except Exception as e:
-            messagebox.showerror("Erreur", str(e))
-
-    # ///summary
-    # Désactive le scroll global quand le dropdown du Combobox est *ouvert*,
-    # puis le réactive quand il se *ferme*. S’appuie sur le popdown interne Tk.
-    def _install_combobox_scroll_guard(self, combobox: ttk.Combobox):
-        # Crée/récupère la fenêtre popdown interne du Combobox
-        pop_path = combobox.tk.call("ttk::combobox::PopdownWindow", combobox)
-        try:
-            pop = self.nametowidget(pop_path)  # Toplevel du dropdown
-        except Exception:
-            return  # sécurité
-
-        # Ouverture du dropdown → suspend le scroll de la ScrollableFrame
-        pop.bind("<Map>", lambda e: self._on_combo_open(), add="+")
-        # Fermeture du dropdown → réactive le scroll
-        pop.bind("<Unmap>", lambda e: self._on_combo_close(), add="+")
-
-    def _on_combo_open(self):
-        if hasattr(self, "_scroll") and self._scroll is not None:
-            self._scroll.suspend_wheel()
-
-    def _on_combo_close(self):
-        if hasattr(self, "_scroll") and self._scroll is not None:
-            self._scroll.resume_wheel()
+            self.skill_created.emit()
+        except Exception as exc:
+            QMessageBox.critical(self, "Erreur", str(exc))

--- a/Skill Creator/Program/ui_main.py
+++ b/Skill Creator/Program/ui_main.py
@@ -1,106 +1,216 @@
 # -*- coding: utf-8 -*-
-"""
-///summary
-Fenêtre principale + navigation et menu.
-"""
-import os
+"""Main window for the Skill Creator Qt application."""
+from __future__ import annotations
+
 import json
-import tkinter as tk
-from tkinter import ttk, filedialog, messagebox
+import os
 from typing import Optional
 
+from PySide6.QtCore import Qt, QSettings
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import (
+    QApplication,
+    QDialog,
+    QDialogButtonBox,
+    QCheckBox,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QMessageBox,
+    QWidget,
+    QVBoxLayout,
+    QTabWidget,
+    QToolButton,
+    QFileDialog,
+)
+from qt_material import apply_stylesheet
+
 from .datastore import DataStore
-from .ui_create_family import CreateFamilyFrame
-from .ui_create_skill import CreateSkillFrame
-from .ui_view_skills import ViewSkillsFrame
-from .ui_view_families import ViewFamiliesFrame  # ← NOUVEAU
+from .ui_create_family import CreateFamilyTab
+from .ui_create_skill import CreateSkillTab
+from .ui_view_skills import ViewSkillsTab
+from .ui_view_families import ViewFamiliesTab
 
-PAD = 8
 
-class MainWindow(tk.Tk):
-    def __init__(self, store: DataStore):
-        super().__init__()
-        self.title("Skill Utility")
-        self.geometry("980x660")
-        self.minsize(820, 520)
+class MainWindow(QMainWindow):
+    """Main window hosting the different application tabs."""
+
+    THEMES = ("red", "pink", "purple", "blue", "cyan", "teal", "lightgreen", "yellow", "amber")
+
+    def __init__(self, store: DataStore, app: QApplication, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Skill Utility")
+        self.resize(1100, 720)
+
+        self.app = app
         self.store = store
 
-        self._build_menu()
-        self._build_main_buttons()
-        self._current_frame: Optional[tk.Frame] = None
-        self.show_view_skills()
+        self.settings = QSettings("UnifoxGameStudio", "SkillCreator")
+        self._is_dark = self.settings.value("ui/is_dark", True, type=bool)
+        self._theme_color = self.settings.value("ui/theme_color", "teal", type=str)
+        self._apply_theme_values(self._is_dark, self._theme_color)
 
-    def _build_menu(self) -> None:
-        menubar = tk.Menu(self)
-        file_menu = tk.Menu(menubar, tearoff=0)
-        file_menu.add_command(label="Ouvrir un JSON…", command=self._load_other_file)
-        file_menu.add_command(label="Exporter JSON sous…", command=self._export_as)
-        file_menu.add_separator()
-        file_menu.add_command(label="Quitter", command=self.destroy)
-        menubar.add_cascade(label="Fichier", menu=file_menu)
-
-        help_menu = tk.Menu(menubar, tearoff=0)
-        help_menu.add_command(label="À propos", command=self._about)
-        menubar.add_cascade(label="Aide", menu=help_menu)
-        self.config(menu=menubar)
-
-    def _build_main_buttons(self) -> None:
-        container = ttk.Frame(self)
-        container.pack(fill="both", expand=True, padx=PAD, pady=PAD)
-
-        header = ttk.Label(container, text="Gestion des Compétences", font=("Segoe UI", 16, "bold"))
-        header.pack(pady=(0, PAD))
-
-        btns = ttk.Frame(container)
-        btns.pack(pady=(0, PAD))
-
-        ttk.Button(btns, text="Créer Famille", width=24, command=self.show_create_family).grid(row=0, column=0, padx=PAD, pady=PAD)
-        ttk.Button(btns, text="Créer Compétence", width=24, command=self.show_create_skill).grid(row=0, column=1, padx=PAD, pady=PAD)
-        ttk.Button(btns, text="Afficher Compétences", width=24, command=self.show_view_skills).grid(row=0, column=2, padx=PAD, pady=PAD)
-        ttk.Button(btns, text="Afficher Familles", width=24, command=self.show_view_families).grid(row=0, column=3, padx=PAD, pady=PAD)  # ← NOUVEAU
-
-        self._frame_host = ttk.Frame(container)
-        self._frame_host.pack(fill="both", expand=True)
-
-    def _swap_frame(self, frame: tk.Frame) -> None:
-        if hasattr(self, "_current_frame") and self._current_frame is not None:
-            self._current_frame.destroy()
-        self._current_frame = frame
-        self._current_frame.pack(fill="both", expand=True)
-
-    def show_create_family(self) -> None:
-        self._swap_frame(CreateFamilyFrame(self._frame_host, self.store))
-
-    def show_create_skill(self) -> None:
-        self._swap_frame(CreateSkillFrame(self._frame_host, self.store))
-
-    def show_view_skills(self) -> None:
-        self._swap_frame(ViewSkillsFrame(self._frame_host, self.store))
-
-    def show_view_families(self) -> None:  # ← NOUVEAU
-        self._swap_frame(ViewFamiliesFrame(self._frame_host, self.store))
-
-    def _load_other_file(self) -> None:
-        path = filedialog.askopenfilename(
-            title="Ouvrir un JSON",
-            filetypes=[("JSON files", "*.json")],
-            initialdir=os.path.dirname(self.store.path),
+        self._tabs = QTabWidget(self)
+        self._tabs.setDocumentMode(True)
+        self._tabs.setStyleSheet(
+            """
+            QTabBar::tab {
+                height: 40px;
+                padding: 8px 16px;
+                font-size: 12.5px;
+            }
+            """
         )
+        self.setCentralWidget(self._tabs)
+
+        self.tab_create_family = CreateFamilyTab(self.store)
+        self.tab_create_skill = CreateSkillTab(self.store)
+        self.tab_view_skills = ViewSkillsTab(self.store)
+        self.tab_view_families = ViewFamiliesTab(self.store)
+
+        self._tabs.addTab(self.tab_view_skills, "Afficher Compétences")
+        self._tabs.addTab(self.tab_create_skill, "Créer Compétence")
+        self._tabs.addTab(self.tab_create_family, "Créer Famille")
+        self._tabs.addTab(self.tab_view_families, "Afficher Familles")
+
+        self.tab_create_family.family_created.connect(self._on_family_created)
+        self.tab_create_skill.skill_created.connect(self._on_skill_created)
+
+        self._tabs.currentChanged.connect(self._maybe_refresh)
+
+        corner = QWidget(self)
+        hlay = QHBoxLayout(corner)
+        hlay.setContentsMargins(0, 0, 8, 0)
+        hlay.setSpacing(6)
+
+        self._btn_theme = QToolButton(corner)
+        self._btn_theme.setCursor(Qt.PointingHandCursor)
+        self._btn_theme.setToolTip("Basculer le thème (Dark/Light)")
+        self._btn_theme.clicked.connect(self._toggle_theme)
+        self._btn_theme.setStyleSheet("QToolButton { padding: 6px 14px; }")
+        hlay.addWidget(self._btn_theme)
+
+        self._btn_config = QToolButton(corner)
+        self._btn_config.setCursor(Qt.PointingHandCursor)
+        self._btn_config.setText("⚙️ Config")
+        self._btn_config.setToolTip("Ouvrir les préférences (couleur, Dark/Light, etc.)")
+        self._btn_config.clicked.connect(self._open_config_dialog)
+        self._btn_config.setStyleSheet("QToolButton { padding: 6px 14px; }")
+        hlay.addWidget(self._btn_config)
+
+        corner.setFixedHeight(46)
+        self._tabs.setCornerWidget(corner, Qt.TopRightCorner)
+
+        self._apply_theme()
+        self._update_theme_button_caption()
+
+        self._build_menu()
+
+    # ----- UI helpers -----------------------------------------------------
+    def _build_menu(self) -> None:
+        menubar = self.menuBar()
+
+        file_menu = menubar.addMenu("Fichier")
+        file_menu.addAction(self._create_action("Ouvrir un JSON…", self._load_other_file))
+        file_menu.addAction(self._create_action("Exporter JSON sous…", self._export_as))
+        file_menu.addSeparator()
+        file_menu.addAction(self._create_action("Quitter", self.close))
+
+        help_menu = menubar.addMenu("Aide")
+        help_menu.addAction(self._create_action("À propos", self._about))
+
+    def _create_action(self, text: str, slot) -> QAction:
+        act = QAction(text, self)
+        act.triggered.connect(slot)
+        return act
+
+    def _maybe_refresh(self, idx: int) -> None:
+        widget = self._tabs.widget(idx)
+        if hasattr(widget, "refresh"):
+            try:
+                widget.refresh()
+            except Exception:
+                pass
+
+    # ----- Theme handling -------------------------------------------------
+    def _toggle_theme(self) -> None:
+        self._is_dark = not self._is_dark
+        self._apply_theme()
+        self._update_theme_button_caption()
+        self.settings.setValue("ui/is_dark", self._is_dark)
+
+    def _apply_theme(self) -> None:
+        self._apply_theme_values(self._is_dark, self._theme_color)
+
+    def _apply_theme_values(self, is_dark: bool, color: str) -> None:
+        chosen = (color or "blue").lower()
+        if chosen not in self.THEMES:
+            chosen = "blue"
+        theme_name = f"{'dark' if is_dark else 'light'}_{chosen}.xml"
+        try:
+            apply_stylesheet(self.app, theme=theme_name, invert_secondary=(not is_dark and False))
+        except Exception:
+            apply_stylesheet(self.app, theme='dark_blue.xml' if is_dark else 'light_blue.xml')
+
+    def _preview_theme(self, *, is_dark: Optional[bool] = None, color: Optional[str] = None) -> None:
+        tmp_dark = self._is_dark if is_dark is None else is_dark
+        tmp_color = self._theme_color if color is None else color
+        self._apply_theme_values(tmp_dark, tmp_color)
+
+    def _update_theme_button_caption(self) -> None:
+        if hasattr(self, "_btn_theme") and self._btn_theme:
+            self._btn_theme.setText("🌙 Dark" if self._is_dark else "☀️ Light")
+
+    def _open_config_dialog(self) -> None:
+        dlg = _ConfigDialog(self)
+        if dlg.exec():
+            is_dark, color = dlg.values()
+            changed = (is_dark != self._is_dark) or (color != self._theme_color)
+            self._is_dark = is_dark
+            self._theme_color = color
+            if changed:
+                self._apply_theme()
+                self._update_theme_button_caption()
+                self.settings.setValue("ui/is_dark", self._is_dark)
+                self.settings.setValue("ui/theme_color", self._theme_color)
+                self._maybe_refresh(self._tabs.currentIndex())
+
+    # ----- Data handling --------------------------------------------------
+    def _on_family_created(self) -> None:
+        self.tab_create_skill.refresh_families()
+        self.tab_view_families.refresh()
+
+    def _on_skill_created(self) -> None:
+        self.tab_view_skills.refresh()
+
+    def _set_store(self, store: DataStore) -> None:
+        self.store = store
+        for tab in (self.tab_create_family, self.tab_create_skill, self.tab_view_skills, self.tab_view_families):
+            tab.set_store(store)
+        self.tab_create_skill.refresh_families()
+        self.tab_view_skills.refresh()
+        self.tab_view_families.refresh()
+
+    # ----- Menu actions ---------------------------------------------------
+    def _load_other_file(self) -> None:
+        initial_dir = os.path.dirname(self.store.path) if self.store.path else os.getcwd()
+        path, _ = QFileDialog.getOpenFileName(self, "Ouvrir un JSON", initial_dir, "JSON files (*.json)")
         if not path:
             return
         try:
-            self.store = DataStore(path=path)
-            self.show_view_skills()
-            messagebox.showinfo("Ouvert", f"Fichier chargé:\n{path}")
-        except Exception as e:
-            messagebox.showerror("Erreur", f"Impossible de charger le fichier:\n{e}")
+            new_store = DataStore(path=path)
+            self._set_store(new_store)
+            QMessageBox.information(self, "Ouvert", f"Fichier chargé:\n{path}")
+        except Exception as exc:
+            QMessageBox.critical(self, "Erreur", f"Impossible de charger le fichier:\n{exc}")
 
     def _export_as(self) -> None:
-        path = filedialog.asksaveasfilename(
-            title="Exporter JSON",
-            defaultextension=".json",
-            filetypes=[("JSON files", "*.json")],
-            initialfile="skills_data_export.json",
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Exporter JSON",
+            os.path.join(os.path.dirname(self.store.path), "skills_data_export.json"),
+            "JSON files (*.json)",
         )
         if not path:
             return
@@ -109,15 +219,86 @@ class MainWindow(tk.Tk):
                 "families": [f.__dict__ for f in self.store.families],
                 "skills": [s.__dict__ for s in self.store.skills],
             }
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump(payload, f, ensure_ascii=False, indent=2)
-            messagebox.showinfo("Exporté", f"Données exportées vers:\n{path}")
-        except Exception as e:
-            messagebox.showerror("Erreur", f"Export impossible:\n{e}")
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, ensure_ascii=False, indent=2)
+            QMessageBox.information(self, "Exporté", f"Données exportées vers:\n{path}")
+        except Exception as exc:
+            QMessageBox.critical(self, "Erreur", f"Export impossible:\n{exc}")
 
     def _about(self) -> None:
-        messagebox.showinfo(
+        QMessageBox.information(
+            self,
             "À propos",
-            "Skill Utility (multi-fichiers)\n\nCréer des familles, créer des compétences,\n"
-            "afficher les compétences et lister les familles.\n\nFichier: skills_data.json (dans le dossier du package)"
+            (
+                "Skill Utility (édition Qt)\n\n"
+                "Créer des familles, créer des compétences,\n"
+                "afficher les compétences et lister les familles.\n\n"
+                "Fichier: skills_data.json (dans le dossier du package)"
+            ),
         )
+
+
+class _ConfigDialog(QDialog):
+    """Configuration dialog for theme selection."""
+
+    def __init__(self, parent: MainWindow):
+        super().__init__(parent)
+        self.setWindowTitle("Préférences")
+        self.setModal(True)
+
+        lay = QVBoxLayout(self)
+
+        self._orig_dark = parent._is_dark
+        self._orig_color = parent._theme_color
+
+        self.chk_dark = QCheckBox("Mode sombre (Dark)")
+        self.chk_dark.setChecked(parent._is_dark)
+        lay.addWidget(self.chk_dark)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Couleur d'accent :"))
+        self.cmb_color = QComboBox()
+        self.cmb_color.addItems(parent.THEMES)
+        try:
+            idx = parent.THEMES.index(parent._theme_color)
+        except ValueError:
+            idx = parent.THEMES.index("blue")
+        self.cmb_color.setCurrentIndex(idx)
+        row.addWidget(self.cmb_color, 1)
+        lay.addLayout(row)
+
+        self.chk_dark.toggled.connect(
+            lambda value: parent._preview_theme(is_dark=value, color=self.cmb_color.currentText())
+        )
+        self.cmb_color.currentTextChanged.connect(
+            lambda color: parent._preview_theme(is_dark=self.chk_dark.isChecked(), color=color)
+        )
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        lay.addWidget(buttons)
+
+        self.rejected.connect(self._restore_original_theme)
+
+    def _restore_original_theme(self) -> None:
+        parent: MainWindow = self.parent()  # type: ignore
+        parent._apply_theme_values(self._orig_dark, self._orig_color)
+        parent._update_theme_button_caption()
+
+    def accept(self) -> None:
+        parent: MainWindow = self.parent()  # type: ignore
+        parent._is_dark, parent._theme_color = self.values()
+        parent._apply_theme()
+        parent._update_theme_button_caption()
+        parent.settings.setValue("ui/is_dark", parent._is_dark)
+        parent.settings.setValue("ui/theme_color", parent._theme_color)
+        parent._maybe_refresh(parent._tabs.currentIndex())
+        super().accept()
+
+    def reject(self) -> None:
+        self._restore_original_theme()
+        super().reject()
+
+    def values(self) -> tuple[bool, str]:
+        return self.chk_dark.isChecked(), self.cmb_color.currentText()

--- a/Skill Creator/Program/widgets.py
+++ b/Skill Creator/Program/widgets.py
@@ -1,168 +1,67 @@
 # -*- coding: utf-8 -*-
-"""
-///summary
-Widgets réutilisables (labels + inputs).
-"""
-import tkinter as tk
-from tkinter import ttk
+"""Reusable Qt widgets for the Skill Creator application."""
+from __future__ import annotations
+
 from typing import List
 
-class LabeledEntry(ttk.Frame):
-    def __init__(self, master, label: str, width: int = 40, **kwargs):
-        super().__init__(master, **kwargs)
-        ttk.Label(self, text=label).pack(anchor="w")
-        self.var = tk.StringVar()
-        self.entry = ttk.Entry(self, textvariable=self.var, width=width)
-        self.entry.pack(fill="x")
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QLineEdit, QTextEdit
 
-class LabeledText(ttk.Frame):
-    def __init__(self, master, label: str, height: int = 4, **kwargs):
-        super().__init__(master, **kwargs)
-        ttk.Label(self, text=label + " (1 par ligne)").pack(anchor="w")
-        self.text = tk.Text(self, height=height, wrap="word")
-        self.text.pack(fill="both", expand=True)
+
+class LabeledLineEdit(QWidget):
+    """Simple widget combining a label and a line edit."""
+
+    def __init__(self, label: str, width: int | None = None, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self._label = QLabel(label)
+        layout.addWidget(self._label)
+
+        self._line = QLineEdit()
+        if width:
+            self._line.setMaximumWidth(width * 8)
+        layout.addWidget(self._line)
+
+    def text(self) -> str:
+        return self._line.text()
+
+    def setText(self, value: str) -> None:  # noqa: N802 (Qt naming convention)
+        self._line.setText(value)
+
+    def set_label_visible(self, visible: bool) -> None:
+        self._label.setVisible(visible)
+
+    def setPlaceholderText(self, text: str) -> None:
+        self._line.setPlaceholderText(text)
+
+
+class LabeledTextEdit(QWidget):
+    """Widget combining a label and a QTextEdit with helper methods."""
+
+    def __init__(self, label: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self._label = QLabel(f"{label} (1 par ligne)")
+        layout.addWidget(self._label)
+
+        self._text = QTextEdit()
+        self._text.setAcceptRichText(False)
+        layout.addWidget(self._text)
+
     def get_lines(self) -> List[str]:
-        raw = self.text.get("1.0", "end").strip()
+        raw = self._text.toPlainText().strip()
         return [line.strip() for line in raw.splitlines() if line.strip()]
 
-# -*- coding: utf-8 -*-
-"""
-///summary
-Frame scrollable verticale (Canvas + Frame) avec molette globale (bind_all)
-activée uniquement quand la souris est dans le scrollview, largeur auto.
-"""
-import tkinter as tk
-from tkinter import ttk
+    def clear(self) -> None:
+        self._text.clear()
 
-class ScrollableFrame(ttk.Frame):
-    def __init__(self, master, **kwargs):
-        super().__init__(master, **kwargs)
+    def setPlainText(self, text: str) -> None:
+        self._text.setPlainText(text)
 
-        self._canvas = tk.Canvas(self, highlightthickness=0, borderwidth=0)
-        self._vsb = ttk.Scrollbar(self, orient="vertical", command=self._canvas.yview)
-        self._inner = ttk.Frame(self._canvas)
-
-        self._window_id = self._canvas.create_window((0, 0), window=self._inner, anchor="nw")
-        self._canvas.configure(yscrollcommand=self._vsb.set)
-
-        self._canvas.pack(side="left", fill="both", expand=True)
-        self._vsb.pack(side="right", fill="y")
-
-        # Largeur auto + scrollregion
-        self._inner.bind("<Configure>", lambda e: self._canvas.configure(scrollregion=self._canvas.bbox("all")))
-        self._canvas.bind("<Configure>", self._on_canvas_configure)
-
-        # État : souris à l'intérieur ?
-        self._inside = False
-        self._wsys = self.tk.call('tk', 'windowingsystem')  # 'win32' / 'aqua' / 'x11'
-
-        # Active/désactive le scroll global quand on ENTRE/SORT
-        # → on écoute à la fois le canvas et la frame interne
-        for w in (self._canvas, self._inner):
-            w.bind("<Enter>", self._on_enter, add="+")
-            w.bind("<Leave>", self._on_leave, add="+")
-
-    def _on_canvas_configure(self, event):
-        # Forcer la largeur du contenu = largeur visible du canvas
-        self._canvas.itemconfigure(self._window_id, width=event.width)
-
-    # --- Gestion entrée/sortie de la zone -----------------------------------
-    def _on_enter(self, _evt=None):
-        if self._inside:
-            return
-        self._inside = True
-        self._activate_global_wheel()
-
-    def _on_leave(self, _evt=None):
-        # Vérifie si la souris est encore sur le canvas/inner; sinon on désactive
-        x_root, y_root = self.winfo_pointerxy()
-        widget_under = self.winfo_containing(x_root, y_root)
-        if widget_under in (self._canvas, self._inner) or self._is_child_of(widget_under, self._inner):
-            return
-        self._inside = False
-        self._deactivate_global_wheel()
-
-    def _is_child_of(self, widget, parent):
-        """Retourne True si widget est un descendant de parent."""
-        while widget is not None:
-            if widget is parent:
-                return True
-            widget = widget.master
-        return False
-
-    # --- Activer/Désactiver bindings globaux de molette ---------------------
-    def _activate_global_wheel(self):
-        # Bind sur la toplevel (global) pour choper l'événement où qu'il arrive
-        top = self.winfo_toplevel()
-        if self._wsys in ('win32', 'aqua'):
-            top.bind_all("<MouseWheel>", self._on_mousewheel, add="+")
-            top.bind_all("<Shift-MouseWheel>", self._on_shift_wheel, add="+")
-        else:  # Linux/X11
-            top.bind_all("<Button-4>", self._on_button4, add="+")
-            top.bind_all("<Button-5>", self._on_button5, add="+")
-
-    def _deactivate_global_wheel(self):
-        top = self.winfo_toplevel()
-        try:
-            if self._wsys in ('win32', 'aqua'):
-                top.unbind_all("<MouseWheel>")
-                top.unbind_all("<Shift-MouseWheel>")
-            else:
-                top.unbind_all("<Button-4>")
-                top.unbind_all("<Button-5>")
-        except Exception:
-            pass
-
-    # --- Handlers molette ----------------------------------------------------
-    def _on_mousewheel(self, event):
-        # Si on a quitté entre temps, ignore
-        if not self._inside:
-            return
-        # Windows: delta multiple de 120 ; macOS: petit delta mais signe identique
-        units = int(-event.delta / 120) if event.delta else 0
-        if units == 0:
-            units = -1 if event.delta > 0 else 1
-        self._canvas.yview_scroll(units, "units")
-
-    def _on_shift_wheel(self, event):
-        if not self._inside:
-            return
-        units = int(-event.delta / 120) if event.delta else 0
-        if units == 0:
-            units = -1 if event.delta > 0 else 1
-        self._canvas.xview_scroll(units, "units")
-
-    def _on_button4(self, _event):
-        if not self._inside:
-            return
-        self._canvas.yview_scroll(-1, "units")
-
-    def _on_button5(self, _event):
-        if not self._inside:
-            return
-        self._canvas.yview_scroll(1, "units")
-
-    @property
-    def body(self) -> ttk.Frame:
-        """Frame interne dans laquelle ajouter les champs."""
-        return self._inner
-        
-        # --- API publique pour geler/dégeler la molette depuis l'extérieur ---
-    def suspend_wheel(self):
-        """Désactive les bindings globaux de molette (utile quand un popdown est ouvert)."""
-        try:
-            self._deactivate_global_wheel()
-        except Exception:
-            pass
-
-    def resume_wheel(self):
-        """Réactive les bindings globaux de molette si la souris est encore dans la zone."""
-        try:
-            # On ne réactive que si le pointeur est dedans (sinon, laisse inactif)
-            x_root, y_root = self.winfo_pointerxy()
-            widget_under = self.winfo_containing(x_root, y_root)
-            if widget_under in (self._canvas, self._inner) or self._is_child_of(widget_under, self._inner):
-                self._activate_global_wheel()
-        except Exception:
-            pass
-
+    def toPlainText(self) -> str:
+        return self._text.toPlainText()

--- a/Skill Creator/app.py
+++ b/Skill Creator/app.py
@@ -1,17 +1,23 @@
 # -*- coding: utf-8 -*-
-"""
-///summary
-Point d'entrée de l'application GUI.
-"""
+"""Entry point for the Skill Creator application (Qt edition)."""
+from __future__ import annotations
+
 import sys
+from PySide6.QtWidgets import QApplication
+
 from Program.datastore import DataStore
 from Program.ui_main import MainWindow
 
-def main(custom_path=None):
+
+def main(custom_path: str | None = None) -> int:
+    """Start the Qt application."""
+    qt_app = QApplication(sys.argv)
     store = DataStore(path=custom_path) if custom_path else DataStore()
-    app = MainWindow(store)
-    app.mainloop()
+    window = MainWindow(store, qt_app)
+    window.show()
+    return qt_app.exec()
+
 
 if __name__ == "__main__":
     custom = sys.argv[1] if len(sys.argv) > 1 else None
-    main(custom_path=custom)
+    sys.exit(main(custom_path=custom))


### PR DESCRIPTION
## Summary
- replace the Tkinter application shell with a PySide6 main window that supports qt_material themes, a dark/light toggle, and a preferences dialog
- rebuild the create/view tabs with Qt widgets, including refreshed family/skill forms and clipboard/export actions backed by the existing datastore
- ensure the skill detail pane omits the difficulty line when its value is "Difficulté : 0"

## Testing
- python -m compileall 'Skill Creator'

------
https://chatgpt.com/codex/tasks/task_e_68d6a58efc84832d9081f4ed282036ad