### PR TITLE
Copy inverted difficulty value to clipboard

### DIFF
--- a/PotionBuilder/js/shared/current-potion.js
+++ b/PotionBuilder/js/shared/current-potion.js
@@ -102,6 +102,21 @@ async function render() {
     btn.type = "button";
     btn.className = "statBtn catBtn";
     btn.textContent = `${t.icon} ${t.label} : ${t.value}`;
+
+    if (t.label === "Difficulté"){
+      btn.title = "Cliquer pour copier la difficulté inversée";
+      btn.addEventListener("click", async () => {
+        const diff = Number(result?.totalDifficulty ?? 0);
+        const inverted = diff * -1;
+        try {
+          if (!navigator?.clipboard?.writeText) throw new Error("clipboard API non disponible");
+          await navigator.clipboard.writeText(String(inverted));
+        } catch (error) {
+          console.error("[current-potion] clipboard error:", error);
+        }
+      });
+    }
+
     elTotals.append(btn);
   }
 


### PR DESCRIPTION
## Summary
- add a click handler to the "Difficulté" stat button in the current potion bar
- copy the negated difficulty value to the clipboard when clicked and guard against missing Clipboard API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a0adc2f4832dab49f52b59fe3132